### PR TITLE
3.0: prompt → prompts

### DIFF
--- a/modules/@apostrophecms/user/index.js
+++ b/modules/@apostrophecms/user/index.js
@@ -412,6 +412,7 @@ module.exports = {
           {
             type: 'password',
             name: 'password',
+            message: `Enter a password for ${username}:`,
             validate () {
               return 'Password is required';
             }
@@ -445,6 +446,7 @@ module.exports = {
           {
             type: 'password',
             name: 'password',
+            message: `Change password for ${username} to:`,
             validate () {
               return 'Password is required';
             }

--- a/modules/@apostrophecms/user/index.js
+++ b/modules/@apostrophecms/user/index.js
@@ -30,7 +30,7 @@
 // such as `@apostrophecms/signup`.
 
 const credential = require('credential');
-const prompt = require('prompt');
+const prompts = require('prompts');
 const Promise = require('bluebird');
 
 module.exports = {
@@ -407,18 +407,20 @@ module.exports = {
           throw 'You must specify --username=usernamehere';
         }
         const req = self.apos.task.getReq();
-        prompt.start();
-        const result = await Promise.promisify(prompt.get, { context: prompt })({
-          properties: {
-            password: {
-              required: true,
-              hidden: true
+
+        const { password } = prompts(
+          {
+            type: 'password',
+            name: 'password',
+            validate () {
+              return 'Password is required';
             }
           }
-        });
+        );
+
         return self.apos.user.insert(req, {
           username: username,
-          password: result.password,
+          password: password,
           title: username,
           firstName: username
         });
@@ -439,16 +441,15 @@ module.exports = {
           throw new Error('No such user.');
         }
 
-        prompt.start();
-
-        const { password } = await Promise.promisify(prompt.get, { context: prompt })({
-          properties: {
-            password: {
-              required: true,
-              hidden: true
+        const { password } = prompts(
+          {
+            type: 'password',
+            name: 'password',
+            validate () {
+              return 'Password is required';
             }
           }
-        });
+        );
 
         // This module's docBeforeUpdate handler does all the magic here
         user.password = password;

--- a/modules/@apostrophecms/user/index.js
+++ b/modules/@apostrophecms/user/index.js
@@ -413,8 +413,8 @@ module.exports = {
             type: 'password',
             name: 'password',
             message: `Enter a password for ${username}:`,
-            validate () {
-              return 'Password is required';
+            validate (input) {
+              return input ? true : 'Password is required';
             }
           }
         );
@@ -447,8 +447,8 @@ module.exports = {
             type: 'password',
             name: 'password',
             message: `Change password for ${username} to:`,
-            validate () {
-              return 'Password is required';
+            validate (input) {
+              return input ? true : 'Password is required';
             }
           }
         );

--- a/modules/@apostrophecms/user/index.js
+++ b/modules/@apostrophecms/user/index.js
@@ -408,7 +408,7 @@ module.exports = {
         }
         const req = self.apos.task.getReq();
 
-        const { password } = prompts(
+        const { password } = await prompts(
           {
             type: 'password',
             name: 'password',
@@ -442,7 +442,7 @@ module.exports = {
           throw new Error('No such user.');
         }
 
-        const { password } = prompts(
+        const { password } = await prompts(
           {
             type: 'password',
             name: 'password',

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "postcss-loader": "^3.0.0",
     "postcss-prefixer": "^2.1.2",
     "postcss-scss": "^2.1.1",
-    "prompt": "^0.2.14",
+    "prompts": "^2.4.0",
     "prosemirror-tables": "^0.9.5",
     "qs": "^6.9.4",
     "regexp-quote": "0.0.0",


### PR DESCRIPTION
Due to dependency on an old version of `winston`, use `prompts` instead of `prompt`